### PR TITLE
Add timing logging

### DIFF
--- a/src/live_portrait_wrapper.py
+++ b/src/live_portrait_wrapper.py
@@ -11,7 +11,7 @@ import cv2
 import torch
 import yaml
 
-from .utils.timer import Timer
+from .utils.timer import Timer, log_time
 from .utils.helper import load_model, concat_feat
 from .utils.camera import headpose_pred_to_degree, get_rotation_matrix
 from .utils.retargeting_utils import calc_eye_close_ratio, calc_lip_close_ratio
@@ -80,6 +80,7 @@ class LivePortraitWrapper(object):
             if hasattr(self.inference_cfg, k):
                 setattr(self.inference_cfg, k, v)
 
+    @log_time
     def prepare_source(self, img: np.ndarray) -> torch.Tensor:
         """ construct the input as standard
         img: HxWx3, uint8, 256x256
@@ -101,6 +102,7 @@ class LivePortraitWrapper(object):
         x = x.to(self.device)
         return x
 
+    @log_time
     def prepare_videos(self, imgs) -> torch.Tensor:
         """ construct the input as standard
         imgs: NxBxHxWx3, uint8
@@ -119,6 +121,7 @@ class LivePortraitWrapper(object):
 
         return y
 
+    @log_time
     def extract_feature_3d(self, x: torch.Tensor) -> torch.Tensor:
         """ get the appearance feature of the image by F
         x: Bx3xHxW, normalized to 0~1
@@ -128,6 +131,7 @@ class LivePortraitWrapper(object):
 
         return feature_3d.float()
 
+    @log_time
     def get_kp_info(self, x: torch.Tensor, **kwargs) -> dict:
         """ get the implicit keypoint information
         x: Bx3xHxW, normalized to 0~1
@@ -273,6 +277,7 @@ class LivePortraitWrapper(object):
 
         return kp_driving
 
+    @log_time
     def warp_decode(self, feature_3d: torch.Tensor, kp_source: torch.Tensor, kp_driving: torch.Tensor) -> torch.Tensor:
         """ get the image after the warping of the implicit keypoints
         feature_3d: Bx32x16x64x64, feature volume

--- a/src/utils/cropper.py
+++ b/src/utils/cropper.py
@@ -18,6 +18,7 @@ from .crop import (
 )
 from .io import contiguous
 from .rprint import rlog as log
+from .timer import log_time
 from .face_analysis_diy import FaceAnalysisDIY
 from .human_landmark_runner import LandmarkRunner as HumanLandmark
 
@@ -90,6 +91,7 @@ class Cropper(object):
             if hasattr(self.crop_cfg, k):
                 setattr(self.crop_cfg, k, v)
 
+    @log_time
     def crop_source_image(self, img_rgb_: np.ndarray, crop_cfg: CropConfig):
         # crop a source image and get neccessary information
         img_rgb = img_rgb_.copy()  # copy it
@@ -169,6 +171,7 @@ class Cropper(object):
         return lmk
 
     # TODO: support skipping frame with NO FACE
+    @log_time
     def crop_source_video(self, source_rgb_lst, crop_cfg: CropConfig, **kwargs):
         """Tracking based landmarks/alignment and cropping"""
         trajectory = Trajectory()
@@ -222,6 +225,7 @@ class Cropper(object):
             "M_c2o_lst": trajectory.M_c2o_lst,
         }
 
+    @log_time
     def crop_driving_video(self, driving_rgb_lst, **kwargs):
         """Tracking based landmarks/alignment and cropping"""
         trajectory = Trajectory()
@@ -282,6 +286,7 @@ class Cropper(object):
         }
 
 
+    @log_time
     def calc_lmks_from_cropped_video(self, driving_rgb_crop_lst, **kwargs):
         """Tracking based landmarks/alignment"""
         trajectory = Trajectory()

--- a/src/utils/timer.py
+++ b/src/utils/timer.py
@@ -5,6 +5,9 @@ tools to measure elapsed time
 """
 
 import time
+import functools
+
+from .rprint import rlog as log
 
 class Timer(object):
     """A simple timer."""
@@ -27,3 +30,18 @@ class Timer(object):
     def clear(self):
         self.start_time = 0.
         self.diff = 0.
+
+
+def log_time(func):
+    """Decorator to log the execution time of a function."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        timer = Timer()
+        timer.tic()
+        result = func(*args, **kwargs)
+        elapsed = timer.toc()
+        log(f"{func.__qualname__} took {elapsed:.3f}s")
+        return result
+
+    return wrapper


### PR DESCRIPTION
## Summary
- add `log_time` decorator for basic runtime logging
- log execution time for key data processing steps

## Testing
- `python -m py_compile src/utils/timer.py src/live_portrait_wrapper.py src/utils/cropper.py`