### PR TITLE
Improve macOS defaults

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,8 @@ The entrance of the gradio for human
 """
 
 import os
+import sys
+import torch
 import tyro
 import subprocess
 import gradio as gr
@@ -14,6 +16,11 @@ from src.gradio_pipeline import GradioPipeline
 from src.config.crop_config import CropConfig
 from src.config.argument_config import ArgumentConfig
 from src.config.inference_config import InferenceConfig
+
+# Enable reasonable defaults for macOS users
+if sys.platform == "darwin":
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+    torch.set_float32_matmul_precision("high")
 
 
 def partial_fields(target_class, kwargs):

--- a/inference.py
+++ b/inference.py
@@ -5,6 +5,8 @@ The entrance of humans
 """
 
 import os
+import sys
+import torch
 import os.path as osp
 import tyro
 import subprocess
@@ -12,6 +14,11 @@ from src.config.argument_config import ArgumentConfig
 from src.config.inference_config import InferenceConfig
 from src.config.crop_config import CropConfig
 from src.live_portrait_pipeline import LivePortraitPipeline
+
+# Enable reasonable defaults for macOS users
+if sys.platform == "darwin":
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+    torch.set_float32_matmul_precision("high")
 
 
 def partial_fields(target_class, kwargs):

--- a/speed.py
+++ b/speed.py
@@ -6,12 +6,19 @@ Benchmark the inference speed of each module in LivePortrait.
 TODO: heavy GPT style, need to refactor
 """
 
+import os
+import sys
 import torch
 torch._dynamo.config.suppress_errors = True  # Suppress errors and fall back to eager execution
 
 import yaml
 import time
 import numpy as np
+
+# Enable reasonable defaults for macOS users
+if sys.platform == "darwin":
+    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+    torch.set_float32_matmul_precision("high")
 
 from src.utils.helper import load_model, concat_feat
 from src.config.inference_config import InferenceConfig


### PR DESCRIPTION
## Summary
- enable MPS fallback and high matmul precision on macOS in `inference.py`
- enable the same defaults for `app.py`
- apply macOS defaults to `speed.py`

## Testing
- `python -m py_compile inference.py app.py speed.py`