### PR TITLE
Add nearest 3d upsample with tests

### DIFF
--- a/src/modules/util.py
+++ b/src/modules/util.py
@@ -127,6 +127,21 @@ def avg_pool3d_mps(inp: torch.Tensor, kernel_size, stride=None, padding=0) -> to
         out = out.to(dtype)
     return out
 
+def upsample_nearest3d_mps(inp: torch.Tensor, scale_factor) -> torch.Tensor:
+    """Nearest neighbor upsampling using repeat for MPS."""
+    if fallback_to_torch:
+        return F.interpolate(inp, scale_factor=scale_factor, mode="nearest")
+
+    sf = to_3tuple(scale_factor)
+    out = inp
+    if sf[0] != 1:
+        out = out.repeat_interleave(sf[0], dim=2)
+    if sf[1] != 1:
+        out = out.repeat_interleave(sf[1], dim=3)
+    if sf[2] != 1:
+        out = out.repeat_interleave(sf[2], dim=4)
+    return out
+
 def kp2gaussian(kp, spatial_size, kp_variance):
     """
     Transform a keypoint into gaussian like representation

--- a/tests/test_upsample_nearest3d_mps.py
+++ b/tests/test_upsample_nearest3d_mps.py
@@ -1,0 +1,23 @@
+import sys
+import os
+import torch
+import torch.nn.functional as F
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.modules.util import upsample_nearest3d_mps
+
+
+def _run_case(shape, scale):
+    torch.manual_seed(0)
+    inp = torch.randn(*shape, dtype=torch.float32)
+    expected = F.interpolate(inp, scale_factor=scale, mode="nearest")
+    actual = upsample_nearest3d_mps(inp, scale)
+    assert torch.allclose(actual, expected, atol=1e-5, rtol=1e-4)
+
+
+def test_upsample_basic():
+    _run_case((1, 2, 3, 4, 5), (1, 2, 2))
+
+
+def test_upsample_varying_factors():
+    _run_case((2, 1, 2, 3, 3), (2, 3, 4))


### PR DESCRIPTION
## Summary
- add `upsample_nearest3d_mps` implementation
- test nearest neighbor 3d upsampling against `F.interpolate`

## Testing
- `pytest -q` *(fails: command not found)*