### PR TITLE
Use snakeviz for profiling

### DIFF
--- a/profiling_graph.py
+++ b/profiling_graph.py
@@ -1,83 +1,24 @@
 # coding: utf-8
-"""Utility for generating graphs from profiling tables produced by ``speed.py``.
+"""Utility to visualize profiling results using snakeviz.
 
-The script reads a profiling table (as printed by ``torch.profiler``) and
-creates a bar chart showing the time spent in each operation.
+This script opens a cProfile stats file with :mod:`snakeviz`.
 
 Example usage::
 
-    python profiling_graph.py profile.txt profile.png
-
+    python profiling_graph.py profile.prof
 """
 import argparse
-import re
-import matplotlib.pyplot as plt
-
-
-def parse_profile_table(text):
-    """Parse profiling table text into a list of ``(name, time_ms)`` tuples."""
-    rows = []
-    header_seen = False
-    for line in text.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        if line.startswith('Name'):
-            header_seen = True
-            continue
-        if line.startswith('-'):
-            continue
-        if not header_seen:
-            continue
-        parts = re.split(r"\s{2,}", line)
-        if not parts:
-            continue
-        name = parts[0]
-        time_ms = None
-        for part in parts[1:]:
-            m = re.search(r"([0-9]*\.?[0-9]+)\s*(ms|us)", part)
-            if m:
-                time_ms = float(m.group(1))
-                if m.group(2) == 'us':
-                    time_ms /= 1000.0
-                break
-        if time_ms is not None:
-            rows.append((name, time_ms))
-    return rows
-
-
-def plot_profile(results, output_path):
-    """Save a horizontal bar chart from profiling results."""
-    if not results:
-        raise ValueError("No profiling data to plot.")
-    names, times = zip(*results)
-    plt.figure(figsize=(8, 0.4 * len(names) + 2))
-    plt.barh(names, times, color="#348ABD")
-    plt.xlabel("Time (ms)")
-    plt.title("Profiling Results")
-    plt.gca().invert_yaxis()
-    plt.tight_layout()
-    plt.savefig(str(output_path))
+from snakeviz.cli import main as snakeviz_main
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate a graph image from profiling data"
+        description="Open a profiling stats file with snakeviz"
     )
-    parser.add_argument("input", help="text file with profiling table")
-    parser.add_argument("output", help="output image path")
-    parser.add_argument("--top", type=int, default=10, help="number of operations to plot")
+    parser.add_argument("input", help="path to a .prof stats file")
     args = parser.parse_args()
 
-    with open(args.input, "r") as f:
-        table = f.read()
-
-    data = parse_profile_table(table)[: args.top]
-    if not data:
-        print("No data found in profiling table.")
-        return
-
-    plot_profile(data, args.output)
+    snakeviz_main([args.input])
 
 
 if __name__ == "__main__":

--- a/tests/test_profile_operations.py
+++ b/tests/test_profile_operations.py
@@ -12,6 +12,6 @@ def test_profile_operations_returns_table():
             x = torch.relu(torch.mm(x, x))
         return x
 
-    table = profile_operations(ops, top_k=5)
+    table = profile_operations(ops, row_limit=5)
     assert isinstance(table, str)
     assert "aten::" in table

--- a/tests/test_profiling_graph.py
+++ b/tests/test_profiling_graph.py
@@ -1,17 +1,4 @@
-from profiling_graph import parse_profile_table, plot_profile
+from profiling_graph import main
 
-SAMPLE_TABLE = """
-Name    Self CPU total %  Self CPU total  CPU total %  CPU total
-aten::mm       50.00%      1.000ms        50.00%       1.000ms
-aten::addmm    25.00%      0.500ms        25.00%       0.500ms
-"""
-
-def test_parse_profile_table():
-    data = parse_profile_table(SAMPLE_TABLE)
-    assert data == [("aten::mm", 1.0), ("aten::addmm", 0.5)]
-
-
-def test_plot_profile(tmp_path):
-    out_file = tmp_path / "out.png"
-    plot_profile(parse_profile_table(SAMPLE_TABLE), out_file)
-    assert out_file.exists()
+def test_main_exists():
+    assert callable(main)


### PR DESCRIPTION
## Summary
- replace matplotlib-based profiling graph with snakeviz launcher
- keep all profiler rows by default
- adapt speed benchmark to generate cProfile stats
- update unit tests

## Testing
- `python -m pip install pytest` *(fails: Could not find a version that satisfies the requirement)*
- `pytest -q` *(fails: command not found)*