### PR TITLE
Fix compilation by using contiguous tensors in benchmark

### DIFF
--- a/speed.py
+++ b/speed.py
@@ -55,14 +55,12 @@ def initialize_inputs(batch_size=1, device_id=0):
     )
     kp_source = torch.randn(batch_size, 21, 3, device=device, dtype=torch.float16)
     kp_driving = torch.randn(batch_size, 21, 3, device=device, dtype=torch.float16)
-    source_image = (
-        torch.randn(batch_size, 3, 256, 256, device=device, dtype=torch.float16)
-        .to(memory_format=torch.channels_last)
-    )
-    generator_input = (
-        torch.randn(batch_size, 256, 64, 64, device=device, dtype=torch.float16)
-        .to(memory_format=torch.channels_last)
-    )
+    source_image = torch.randn(
+        batch_size, 3, 256, 256, device=device, dtype=torch.float16
+    ).contiguous()
+    generator_input = torch.randn(
+        batch_size, 256, 64, 64, device=device, dtype=torch.float16
+    ).contiguous()
     eye_close_ratio = torch.randn(batch_size, 3, device=device, dtype=torch.float16)
     lip_close_ratio = torch.randn(batch_size, 2, device=device, dtype=torch.float16)
     feat_stitching = concat_feat(kp_source, kp_driving).half()

--- a/src/modules/convnextv2.py
+++ b/src/modules/convnextv2.py
@@ -33,13 +33,13 @@ class Block(nn.Module):
     def forward(self, x):
         input = x
         x = self.dwconv(x)
-        x = x.permute(0, 2, 3, 1)  # (N, C, H, W) -> (N, H, W, C)
+        x = x.permute(0, 2, 3, 1).contiguous()  # (N, C, H, W) -> (N, H, W, C)
         x = self.norm(x)
         x = self.pwconv1(x)
         x = self.act(x)
         x = self.grn(x)
         x = self.pwconv2(x)
-        x = x.permute(0, 3, 1, 2)  # (N, H, W, C) -> (N, C, H, W)
+        x = x.permute(0, 3, 1, 2).contiguous()  # (N, H, W, C) -> (N, C, H, W)
 
         x = input + self.drop_path(x)
         return x

--- a/src/modules/dense_motion.py
+++ b/src/modules/dense_motion.py
@@ -92,9 +92,9 @@ class DenseMotionNetwork(nn.Module):
         mask = F.softmax(mask, dim=1)  # (bs, 1+num_kp, d=16, h=64, w=64)
         out_dict['mask'] = mask
         mask = mask.unsqueeze(2)                                   # (bs, num_kp+1, 1, d, h, w)
-        sparse_motion = sparse_motion.permute(0, 1, 5, 2, 3, 4)    # (bs, num_kp+1, 3, d, h, w)
+        sparse_motion = sparse_motion.permute(0, 1, 5, 2, 3, 4).contiguous()    # (bs, num_kp+1, 3, d, h, w)
         deformation = (sparse_motion * mask).sum(dim=1)            # (bs, 3, d, h, w)  mask take effect in this place
-        deformation = deformation.permute(0, 2, 3, 4, 1)           # (bs, d, h, w, 3)
+        deformation = deformation.permute(0, 2, 3, 4, 1).contiguous()           # (bs, d, h, w, 3)
 
         out_dict['deformation'] = deformation
 


### PR DESCRIPTION
## Summary
- make generated example inputs contiguous in `speed.py`
- ensure permuted tensors are made contiguous in ConvNeXtV2 blocks
- fix dense motion permute layouts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*